### PR TITLE
Walk score service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@
 /config/master.key
 
 coverage
+application.yml

--- a/app/facades/location_facade.rb
+++ b/app/facades/location_facade.rb
@@ -4,21 +4,56 @@ class LocationFacade
   end
 
   def find_population
-    data = location_service.get_census_data(@location)
-    data[:records].first[:fields][:total_population]
+    location_service[:records].first[:fields][:total_population]
   end
 
   def find_median_age
-    data = location_service.get_census_data(@location)
-    data[:records].first[:fields][:median_age]
+    location_service[:records].first[:fields][:median_age]
   end
 
   def find_avg_household_size
-    data = location_service.get_census_data(@location)
-    data[:records].first[:fields][:average_household_size]
+    location_service[:records].first[:fields][:average_household_size]
   end
 
+  def find_walk_score
+    walk_service[:walkscore]
+  end
+
+  def find_walk_description
+    walk_service[:description]
+  end
+
+  def find_bike_score
+    walk_service[:bike][:score]
+  end
+
+  def find_bike_description
+    walk_service[:bike][:description]
+  end
+
+  def find_longitude
+    coordinates_service[:lng]
+  end
+
+  def find_latitude
+    coordinates_service[:lat]
+  end
+
+  def split_location
+  @location.split(', ')
+end
+
   def location_service
-    OpenDataService.new
+    @_location_service ||= OpenDataService.new.get_census_data(@location)
+  end
+
+  def coordinates_service
+    @_geocoding_service ||= GeocodingService.new.get_coordinates(split_location[0], split_location[1])
+  end
+
+  def walk_service
+    lat = find_latitude
+    lon = find_longitude
+    @_walk_score_service ||= WalkScoreService.new.get_walk_score(lat, lon)
   end
 end

--- a/app/services/geocoding_service.rb
+++ b/app/services/geocoding_service.rb
@@ -1,0 +1,19 @@
+class GeocodingService
+
+  def get_coordinates(city, state)
+    response = conn.get("/maps/api/geocode/json") do |f|
+      f.params[:address] = "#{city}, #{state}"
+    end
+    JSON.parse(response.body, symbolize_names: true)[:results].first[:geometry][:location]
+  end
+
+  private
+
+  def conn
+    Faraday.new('https://maps.googleapis.com') do |faraday|
+      faraday.params[:key] = ENV['google_maps_api_key']
+      faraday.adapter Faraday.default_adapter
+    end
+  end
+  
+end

--- a/app/services/walk_score_service.rb
+++ b/app/services/walk_score_service.rb
@@ -1,0 +1,23 @@
+class WalkScoreService
+
+  def get_walk_score(lat, lon)
+    response = conn.get("/score?") do |f|
+      f.params[:format] = "json"
+      f.params[:lat] = lat
+      f.params[:lon] = lon
+      f.params[:transit] = 1
+      f.params[:bike] = 1
+    end
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  private
+
+  def conn
+    Faraday.new("http://api.walkscore.com/") do |f|
+      f.params[:wsapikey] = ENV['wsapikey']
+      f.adapter Faraday.default_adapter
+    end
+  end
+
+end

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -2,3 +2,5 @@
 <h3>Population: <%= @location_data.find_population %> people</h3>
 <h3>Median Age: <%= @location_data.find_median_age %> years old</h3>
 <h3>Average Household Size: <%= @location_data.find_avg_household_size %> people</h3>
+<h3><%= @location %> is a <%= @location_data.find_walk_description %> and is a <%= @location_data.find_bike_description %></h3>
+<h3>It has a walkability score of <%= @location_data.find_walk_score %> and a bikeability score of <%= @location_data.find_bike_score %></h3>

--- a/spec/features/user_can_search_by_location_spec.rb
+++ b/spec/features/user_can_search_by_location_spec.rb
@@ -24,11 +24,18 @@ describe 'as a user when they visit the sit' do
     location = "Denver, CO"
     median_age = 34.1
     avg_household_size = 2.33
-
+    walk_score = 93
+    walk_description = "Walker's Paradise"
+    bike_score = 94
+    bike_description = "Biker's Paradise"
     expect(page).to have_content("#{location}")
     expect(page).to have_content("Population: #{population} people")
     expect(page).to have_content("Median Age: #{median_age} years old")
     expect(page).to have_content("Average Household Size: #{avg_household_size} people")
+    expect(page).to have_content("#{location} is a #{walk_description}")
+    expect(page).to have_content("It has a walkability score of #{walk_score}")
+    expect(page).to have_content("and is a #{bike_description}")
+    expect(page).to have_content(" and a bikeability score of #{bike_score}")
   end
 
 

--- a/spec/services/walk_score_service_spec.rb
+++ b/spec/services/walk_score_service_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe WalkScoreService do
+  it 'exists' do
+    walk_score_service = WalkScoreService.new
+    expect(walk_score_service).to be_a(WalkScoreService)
+  end
+
+  it 'gets the walk score of a location' do
+    walk_score_service = WalkScoreService.new
+    location = "Denver, CO"
+    # walk_score = walk_score_service.get_census_data(location)[:records].first[:fields][:total_population]
+    # expect(walk_score).to eq(682545)
+  end
+end

--- a/spec/services/walk_score_service_spec.rb
+++ b/spec/services/walk_score_service_spec.rb
@@ -6,10 +6,25 @@ describe WalkScoreService do
     expect(walk_score_service).to be_a(WalkScoreService)
   end
 
-  it 'gets the walk score of a location' do
+  it 'gets the walk score and description of a location' do
     walk_score_service = WalkScoreService.new
-    location = "Denver, CO"
-    # walk_score = walk_score_service.get_census_data(location)[:records].first[:fields][:total_population]
-    # expect(walk_score).to eq(682545)
+    lat = 39.739
+    lon = -104.9903
+
+    walk_score = walk_score_service.get_walk_score(lat, lon)
+    walk_description = walk_score_service.get_walk_score(lat, lon)
+    expect(walk_score[:walkscore]).to eq(93)
+    expect(walk_score[:description]).to eq("Walker's Paradise")
+  end
+
+  it 'gets the bike score and description of a location' do
+    walk_score_service = WalkScoreService.new
+    lat = 39.739
+    lon = -104.9903
+
+    bike_score = walk_score_service.get_walk_score(lat, lon)
+    bike_description = walk_score_service.get_walk_score(lat, lon)
+    expect(bike_score[:bike][:score]).to eq(94)
+    expect(bike_score[:bike][:description]).to eq("Biker's Paradise")
   end
 end


### PR DESCRIPTION
## Waffle Card number(s):
Closes #7 
Closes #8 
Works on #4 

## What does this PR do?
- Adds Geocoding Service to take location and turn it into latitude and longitude in order to use the WalkScore API
- Adds WalkScore Service to consume the WalkScore API
- Adds new API information to Search Result view
- Adds service tests for WalkScore Service and feature tests for displayed information
- 100% coverage, all tests passing
- Need to add tests for geocoding service

<img width="603" alt="Screen Shot 2019-04-13 at 8 34 13 PM" src="https://user-images.githubusercontent.com/41347275/56087594-8802cb80-5e2b-11e9-92fa-0e66b942bc30.png">

